### PR TITLE
adds icon to help page. Closes #13

### DIFF
--- a/src/app/help/help.css
+++ b/src/app/help/help.css
@@ -34,3 +34,17 @@ span.lr {
 	width: 14px;
 	height: 16px;
 }
+
+kbd {
+	display: inline-block;
+	padding: 5px;
+	font-size: 13px;
+	line-height: 10px;
+	color: #555;
+	vertical-align: middle;
+	background-color: #fcfcfc;
+	border: solid 1px #ccc;
+	border-bottom-color: #bbb;
+	border-radius: 3px;
+	box-shadow: inset 0 -1px 0 #bbb;
+}

--- a/src/app/help/help.css
+++ b/src/app/help/help.css
@@ -25,3 +25,12 @@ b {
 .step--0 {
 	opacity: 1;
 }
+
+span.lr {
+	display: inline-block;
+	background: url('../../assets/images/lrTemplate.png') no-repeat 4px 4px;
+	background-color: #f1f1f1;
+	padding: 4px;
+	width: 14px;
+	height: 16px;
+}

--- a/src/app/help/help.html
+++ b/src/app/help/help.html
@@ -18,27 +18,27 @@
 			</header>
 
 			<section class="step step--0">
-				<p>In Linear, you work with <b>rulers</b>. Here is one. Go ahead, grab it around :-)</p>
+				<p>In Linear, you work with <b>rulers</b>. Here is one. Go ahead, move it around :-)</p>
 			</section>
 
 			<section class="step step--1">
-				<p>To manage your rulers, have a look at the <span class="lr">lr<span> icon in the tray bar,
-					located on the top right corner of your screen. From there, you can create new rulers.
+				<p>To manage your rulers, have a look at the <span class="lr"></span> icon in the menu bar,
+					located at the top right corner of your screen. From there, you can create new rulers.
 				You can create as many rulers as you want.</p>
 			</section>
 
 			<section class="step step--2">
-				<p>Shortcuts are really useful! To create a new ruler, press ^⌘R. To hide/show existing
-				rulers, ^⌘T (toggle). To close a ruler, ⌘W.</p>
+				<p>Shortcuts are really useful! To create a new ruler, press ^⌘R. To hide/show (toggle) existing
+				rulers, press ^⌘T . To close a ruler, press ⌘W.</p>
 			</section>
 
 			<section class="step step--3">
-				<p>Right-clicking on a ruler lets you duplicate it. It keeps the ruler's position and size.</p>
+				<p>Right-clicking on a ruler lets you duplicate it. The duplicate ruler keeps the original ruler's size and general position.</p>
 			</section>
 
 			<section class="step step--4">
-				<p>In the settings window (available from clicking the lr icon in the tray bar,) you can change
-				the displayed unit to either px or em.</p>
+				<p>In the settings window (available from clicking the <span class="lr"></span> icon in the menu bar,) you can change
+				the displayed ruler's unit to either px or em.</p>
 			</section>
 
 			<section class="step step--5">

--- a/src/app/help/help.html
+++ b/src/app/help/help.html
@@ -37,7 +37,7 @@
 			</section>
 
 			<section class="step step--4">
-				<p>In the settings window (available from clicking the <span class="lr"></span> icon in the menu bar,) you can change
+				<p>In the settings window (available from clicking the <span class="lr"></span> icon in the menu bar) you can change
 				the displayed ruler's unit to either px or em.</p>
 			</section>
 

--- a/src/app/help/help.html
+++ b/src/app/help/help.html
@@ -28,8 +28,8 @@
 			</section>
 
 			<section class="step step--2">
-				<p>Shortcuts are really useful! To create a new ruler, press ^⌘R. To hide/show (toggle) existing
-				rulers, press ^⌘T . To close a ruler, press ⌘W.</p>
+				<p>Shortcuts are really useful! To create a new ruler, press <kbd>^⌘R</kbd>. To hide/show (toggle) existing
+				rulers, press <kbd>^⌘T</kbd>. To close a ruler, press <kbd>⌘W</kbd>.</p>
 			</section>
 
 			<section class="step step--3">

--- a/src/app/help/help.html
+++ b/src/app/help/help.html
@@ -33,7 +33,7 @@
 			</section>
 
 			<section class="step step--3">
-				<p>Right-clicking on a ruler lets you duplicate it. The duplicate ruler keeps the original ruler's size and general position.</p>
+				<p>Right-clicking on a ruler lets you duplicate it. The duplicated ruler keeps the original ruler's size and general position.</p>
 			</section>
 
 			<section class="step step--4">


### PR DESCRIPTION
- Adds the `lr` icon image to the Help page (styled to emulate the Mac), for better discoverability
- Fixes the unclosed `<span>` element (see issue #13)
- Removes the mention of the duplicated ruler keeping the original ruler's position (because that is no longer true, a position offset has been added to make it more obvious that a new ruler has been added)
- Typos, grammar and formatting
- adds github-style keyboard shortcuts like: <kbd>^⌘R</kbd>

For a preview of the new help page, and to demonstrate the appearance of the new `lr` icons and <kbd>shortcuts</kbd>: 
![kbd-icons](https://cloud.githubusercontent.com/assets/5614571/14061669/c286f130-f37d-11e5-9b2f-00a35f299f1b.png)
