### PR TITLE
Adds Center Guides

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,6 @@ const dataStore = require('./src/data-store');
 // });
 
 let rulers = [];
-let mainWindow;
 let settingsWindow;
 let helpWindow;
 
@@ -28,13 +27,13 @@ let helpWindow;
 function createNewRuler(windowInfo) {
 	let _windowInfo = windowInfo || {};
 	let ruler = new BrowserWindow({
-		width: _windowInfo.width || 151,
-		height: _windowInfo.height || 126,
-		frame: false,
-		transparent: true,
-		alwaysOnTop: true,
-		x: _windowInfo.x,
-		y: _windowInfo.y,
+		'width': _windowInfo.width || 151,
+		'height': _windowInfo.height || 126,
+		'frame': false,
+		'transparent': true,
+		'alwaysOnTop': true,
+		'x': _windowInfo.x,
+		'y': _windowInfo.y,
 		'min-width': 151,
 		'min-height': 126,
 		'standard-window': false,
@@ -114,62 +113,62 @@ function toggleRulerCommand() {
 }
 
 app.dock.hide();
-app.on('ready', function() {
+app.on('ready', function () {
 	let trayIcon = new Tray(path.join(__dirname, 'src/assets/images/lrTemplate.png'));
 
 	var trayMenuTemplate = [
-			{
-				label: 'New Ruler',
-				accelerator: 'Command+Ctrl+R',
-				click: createNewRuler
-			},
-			{
-				label: 'Toggle Rulers',
-				accelerator: 'Command+Ctrl+T',
-				click: toggleRulerCommand,
-				enabled: false
-			},
-			{
-				label: 'Toggle Center Guides',
-				accelerator: 'Command+;',
-				click: toggleCenterGuidesCommand,
-				enabled: true
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Settings',
-				click: () => {
-					if (settingsWindow) {
-						return;
-					}
-
-					settingsWindow = new BrowserWindow({
-						width: 200,
-						height: 170,
-						alwaysOnTop: true
-					});
-
-					settingsWindow.loadURL(`file://${__dirname}/src/app/settings/settings.html`);
-
-					settingsWindow.on('closed', () => {
-						settingsWindow = null;
-					});
+		{
+			label: 'New Ruler',
+			accelerator: 'Command+Ctrl+R',
+			click: createNewRuler
+		},
+		{
+			label: 'Toggle Rulers',
+			accelerator: 'Command+Ctrl+T',
+			click: toggleRulerCommand,
+			enabled: false
+		},
+		{
+			label: 'Toggle Center Guides',
+			accelerator: 'Command+;',
+			click: toggleCenterGuidesCommand,
+			enabled: true
+		},
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Settings',
+			click: () => {
+				if (settingsWindow) {
+					return;
 				}
-			},
-			{
-				label: 'Help',
-				click: showHelp
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Quit',
-				accelerator: 'Command+Q',
-				click: () => app.quit()
+
+				settingsWindow = new BrowserWindow({
+					width: 200,
+					height: 170,
+					alwaysOnTop: true
+				});
+
+				settingsWindow.loadURL(`file://${__dirname}/src/app/settings/settings.html`);
+
+				settingsWindow.on('closed', () => {
+					settingsWindow = null;
+				});
 			}
+		},
+		{
+			label: 'Help',
+			click: showHelp
+		},
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Quit',
+			accelerator: 'Command+Q',
+			click: () => app.quit()
+		}
 	];
 
 	let trayMenu = Menu.buildFromTemplate(trayMenuTemplate);
@@ -180,9 +179,9 @@ app.on('ready', function() {
 	let appMenu = Menu.buildFromTemplate([{
 		label: require('electron').app.getName(),
 		submenu: [{
-				label: 'Quit',
-				accelerator: 'Command+Q',
-				click: () => app.quit()
+			label: 'Quit',
+			accelerator: 'Command+Q',
+			click: () => app.quit()
 		}]
 	}, {
 		label: 'Window',
@@ -196,7 +195,7 @@ app.on('ready', function() {
 	Menu.setApplicationMenu(appMenu);
 
 	// We observe changes on the `rulers` array to enable/disable the toggle menu.
-	Array.observe(rulers, () => toggleRulersMenu.enabled = !!rulers.length);
+	Array.observe(rulers, () => toggleRulersMenu.enabled = Boolean(rulers.length));
 
 	globalShortcut.register('Command + Control + T', toggleRulerCommand);
 	globalShortcut.register('Command + Control + R', createNewRuler);
@@ -212,8 +211,8 @@ app.on('ready', function() {
 });
 
 // We make sure not to quit when all windows are closed.
-app.on('window-all-closed', function() {
-	if (process.platform != 'darwin') {
+app.on('window-all-closed', () => {
+	if (process.platform !== 'darwin') {
 		app.quit();
 	}
 });
@@ -226,12 +225,9 @@ ipc.on('settings-changed', () => {
 
 // Duplicate a given ruler.
 ipc.on('create-ruler', (evt, rulerInfo) => {
-
 	// Offset new duplicate ruler to make it more evident.
 	rulerInfo.x += 10;
 	rulerInfo.y += 10;
 
 	createNewRuler(rulerInfo);
 });
-
-

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const Menu = electron.Menu;
 const path = require('path');
 const dataStore = require('./src/data-store');
 
-//	Uncomment this to see debugging tools.
+// Uncomment this to see debugging tools.
 // require('electron-debug')({
 //     showDevTools: true
 // });
@@ -52,6 +52,13 @@ function createNewRuler(windowInfo) {
 }
 
 /**
+ * Toggle the visibility of the Center Guides
+ */
+function toggleCenterGuidesCommand() {
+	rulers.forEach((ruler) => ruler.send('toggle-center-guides'));
+}
+
+/**
  * Show the help page for better onboarding.
  */
 function showHelp() {
@@ -78,7 +85,7 @@ let hidden = false;
 
 /**
  * Toggle a ruler asynchronously and give back a promise.
- * @param	{BrowserWindow} ruler - The ruler to toggle
+ * @param {BrowserWindow} ruler - The ruler to toggle
  * @return {Promise}
  */
 let toggleRuler = (ruler) => {
@@ -98,7 +105,7 @@ function toggleRulerCommand() {
 
 	hidden = !hidden;
 
-	// Close all rulers sequencially. Doing otherwise doesn't toggle them
+	// Close all rulers sequentially. Doing otherwise doesn't toggle them
 	// properly. This is most likely an issue with Electron.
 	rulers.slice(1).reduce((acc, val) => {
 		return acc.then(() => toggleRuler(val));
@@ -111,15 +118,21 @@ app.on('ready', function() {
 
 	var trayMenuTemplate = [
 			{
-					label: 'New ruler',
-					accelerator: 'Command+Ctrl+R',
-					click: createNewRuler
+				label: 'New Ruler',
+				accelerator: 'Command+Ctrl+R',
+				click: createNewRuler
 			},
 			{
-					label: 'Toggle rulers',
-					accelerator: 'Command+Ctrl+T',
-					click: toggleRulerCommand,
-					enabled: false
+				label: 'Toggle Rulers',
+				accelerator: 'Command+Ctrl+T',
+				click: toggleRulerCommand,
+				enabled: false
+			},
+			{
+				label: 'Toggle Center Guides',
+				accelerator: 'Command+;',
+				click: toggleCenterGuidesCommand,
+				enabled: true
 			},
 			{
 				type: 'separator'
@@ -152,9 +165,9 @@ app.on('ready', function() {
 				type: 'separator'
 			},
 			{
-					label: 'Quit',
-					accelerator: 'Command+Q',
-					click: () => app.quit()
+				label: 'Quit',
+				accelerator: 'Command+Q',
+				click: () => app.quit()
 			}
 	];
 
@@ -186,6 +199,7 @@ app.on('ready', function() {
 
 	globalShortcut.register('Command + Control + T', toggleRulerCommand);
 	globalShortcut.register('Command + Control + R', createNewRuler);
+	globalShortcut.register('Command + ;', toggleCenterGuidesCommand);
 
 	// Show help the first time the app is launched.
 	if (dataStore.readSettings('tutorialShown')) {

--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ function createNewRuler(windowInfo) {
  * Toggle the visibility of the Center Guides in the active ruler
  */
 function toggleCenterGuidesCommand() {
-	var activeRuler = BrowserWindow.getFocusedWindow();
+	let activeRuler = BrowserWindow.getFocusedWindow();
 	if (activeRuler) {
 		activeRuler.send('toggle-center-guides');
 	}

--- a/main.js
+++ b/main.js
@@ -21,8 +21,8 @@ let helpWindow;
 
 /**
  * Create a ruler window and push it to the `rulers` array. The ruler window
- * is frameless, transparent and resizable. This type of windows might not be
- * well supported on every platforms.
+ * is frameless, transparent and resizable. This type of window might not be
+ * well supported on every platform.
  * @param {Object} windowInfo - Size and position of the window
  */
 function createNewRuler(windowInfo) {
@@ -52,10 +52,11 @@ function createNewRuler(windowInfo) {
 }
 
 /**
- * Toggle the visibility of the Center Guides
+ * Toggle the visibility of the Center Guides in the active ruler
  */
 function toggleCenterGuidesCommand() {
-	rulers.forEach((ruler) => ruler.send('toggle-center-guides'));
+	var activeRuler = BrowserWindow.getFocusedWindow();
+	activeRuler.send('toggle-center-guides');
 }
 
 /**
@@ -183,7 +184,7 @@ app.on('ready', function() {
 				accelerator: 'Command+Q',
 				click: () => app.quit()
 		}]
-	},{
+	}, {
 		label: 'Window',
 		role: 'window',
 		submenu: [{
@@ -232,3 +233,5 @@ ipc.on('create-ruler', (evt, rulerInfo) => {
 
 	createNewRuler(rulerInfo);
 });
+
+

--- a/main.js
+++ b/main.js
@@ -34,8 +34,8 @@ function createNewRuler(windowInfo) {
 		'alwaysOnTop': true,
 		'x': _windowInfo.x,
 		'y': _windowInfo.y,
-		'min-width': 151,
-		'min-height': 126,
+		'min-width': 101,
+		'min-height': 101,
 		'standard-window': false,
 		'use-content-size': true
 	});

--- a/main.js
+++ b/main.js
@@ -55,7 +55,9 @@ function createNewRuler(windowInfo) {
  */
 function toggleCenterGuidesCommand() {
 	var activeRuler = BrowserWindow.getFocusedWindow();
-	activeRuler.send('toggle-center-guides');
+	if (activeRuler) {
+		activeRuler.send('toggle-center-guides');
+	}
 }
 
 /**

--- a/main.js
+++ b/main.js
@@ -210,7 +210,7 @@ app.on('ready', function() {
 	}
 });
 
-// We make sure not to quit when every windows are closed.
+// We make sure not to quit when all windows are closed.
 app.on('window-all-closed', function() {
 	if (process.platform != 'darwin') {
 		app.quit();
@@ -226,7 +226,7 @@ ipc.on('settings-changed', () => {
 // Duplicate a given ruler.
 ipc.on('create-ruler', (evt, rulerInfo) => {
 
-	//	Offset new duplicate ruler to make it more evident.
+	// Offset new duplicate ruler to make it more evident.
 	rulerInfo.x += 10;
 	rulerInfo.y += 10;
 

--- a/src/app/help/help.html
+++ b/src/app/help/help.html
@@ -29,7 +29,7 @@
 
 			<section class="step step--2">
 				<p>Shortcuts are really useful! To create a new ruler, press <kbd>^⌘R</kbd>. To hide/show (toggle) existing
-				rulers, press <kbd>^⌘T</kbd>. To close a ruler, press <kbd>⌘W</kbd>.</p>
+				rulers, press <kbd>^⌘T</kbd>. To close a ruler, press <kbd>⌘W</kbd>. To toggle the center guides, press <kbd>⌘;</kbd></p>
 			</section>
 
 			<section class="step step--3">

--- a/src/app/help/help.js
+++ b/src/app/help/help.js
@@ -5,8 +5,8 @@ const remote = require('electron').remote;
 const browserWindow = remote.getCurrentWindow();
 const dataStore = require('../../data-store');
 
-// When the help menu is loaded, we create a ruler so the user can get a feel
-// of how to use them.
+// When the help menu is loaded, we create a ruler
+// so the user can get a feel of how to use them.
 ipc.send('create-ruler', {
 	x: browserWindow.getPosition()[0] + 274,
 	y: browserWindow.getPosition()[1] + 250

--- a/src/app/ruler/ruler.css
+++ b/src/app/ruler/ruler.css
@@ -53,7 +53,7 @@ body {
 }
 
 .ruler__inner__border--left {
-	left: 10em;
+	left: 5em;
 	height: 100%;
 	border-left: 1px solid white;
 }
@@ -71,19 +71,18 @@ body {
 }
 
 .ruler__inner__border--bottom {
-	bottom: 7.5em;
+	bottom: 5em;
 	width: 100%;
 	border-bottom: 1px solid white;
 }
 
 .ruler__inner__info {
 	position: absolute;
-	bottom: 3.4em;
-	left: 1.6em;
+	bottom: 1.2em;
+	left: 5.6em;
 	width: 6.5em;
 	font-size: 1.1em;
 	color: white;
-	text-align: right
 }
 
 .ruler__inner__info__width:before {
@@ -95,7 +94,7 @@ body {
 
 .ruler__inner__info__width,
 .ruler__inner__info__height {
-	text-align: right;
+	text-align: left;
 }
 
 .ruler__inner__title {
@@ -104,14 +103,14 @@ body {
 	font-size: 1.5em;
 	position: absolute;
 	top: 1.45em;
-	left: 5.3em;
+	left: 1.6em;
 	color: white;
 }
 
 .ruler__inner__theme {
 	color: #888;
 	position: absolute;
-	bottom: 5.3em;
+	bottom: 2.5em;
 	right: 3em;
 	cursor: pointer;
 }
@@ -121,4 +120,29 @@ body {
 .dark-theme .ruler__inner__title {
 	border-color: black !important;
 	color: black;
+}
+
+#guide__vertical, #guide__horizontal {
+	position: fixed;
+	box-sizing: border-box;
+}
+
+#guide__vertical {
+	top:0;
+	left: 50%;
+	height: 100%;
+	width: 1px;
+	border-right: dashed red 1px;
+}
+
+#guide__horizontal {
+	top:50%;
+	left: 0;
+	width: 100%;
+	height: 1px;
+	border-top: dashed red 1px;
+}
+
+.hidden {
+	display: none;
 }

--- a/src/app/ruler/ruler.css
+++ b/src/app/ruler/ruler.css
@@ -142,6 +142,10 @@ body {
 	border-top: dashed lightgray 1px;
 }
 
+.darkCenterGuides {
+	border-color: #343434 !important;
+}
+
 .hidden {
 	display: none;
 }

--- a/src/app/ruler/ruler.css
+++ b/src/app/ruler/ruler.css
@@ -34,7 +34,6 @@ body {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	-webkit-clip-path: inset(1em 1em 1em 1em);
 	transition: all .5s ease-out;
 }
 
@@ -132,7 +131,7 @@ body {
 	left: 50%;
 	height: 100%;
 	width: 1px;
-	border-right: dashed red 1px;
+	border-right: dashed lightgray 1px;
 }
 
 #guide__horizontal {
@@ -140,7 +139,7 @@ body {
 	left: 0;
 	width: 100%;
 	height: 1px;
-	border-top: dashed red 1px;
+	border-top: dashed lightgray 1px;
 }
 
 .hidden {

--- a/src/app/ruler/ruler.html
+++ b/src/app/ruler/ruler.html
@@ -8,8 +8,8 @@
 		<link href="ruler.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body>
-		<div id="guide__vertical" class="hidden"></div>
-		<div id="guide__horizontal" class="hidden"></div>
+		<div id="guide__vertical" class="center_guide hidden"></div>
+		<div id="guide__horizontal" class="center_guide hidden"></div>
 		<div class="ruler-mask"></div>
 		<div class="ruler">
 			<div class="ruler__inner">

--- a/src/app/ruler/ruler.html
+++ b/src/app/ruler/ruler.html
@@ -8,6 +8,8 @@
 		<link href="ruler.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body>
+		<div id="guide__vertical" class="hidden"></div>
+		<div id="guide__horizontal" class="hidden"></div>
 		<div class="ruler-mask"></div>
 		<div class="ruler">
 			<div class="ruler__inner">

--- a/src/app/ruler/ruler.js
+++ b/src/app/ruler/ruler.js
@@ -24,7 +24,7 @@ let centerGuides = {
 	horizontal: document.querySelector('#guide__horizontal')
 };
 
-let centerGuidesAreVisible = false;
+let showCenterGuides = false;
 
 let baseFontSize; // Used to calculate em.
 
@@ -112,12 +112,12 @@ window.addEventListener('keyup', function(evt) {
 		right = 39,
 		shift = 16;
 
-	//	Grabbing the current position to add to it.
+	// Grabbing the current position to add to it.
 	let position = browserWindow.getPosition();
 	let x = position[0];
 	let y = position[1];
 
-	//	Figuring out if shiftKey is down to increment by 10px or just 1px
+	// Figuring out if shiftKey is down to increment by 10px or just 1px
 	let increment = isShiftDown ? 10 : 1;
 
 	switch (evt.keyCode) {
@@ -155,9 +155,10 @@ window.addEventListener('resize', updateMesures);
 ipc.on('settings-changed', loadSettings);
 ipc.on('toggle-center-guides', toggleCenterGuides);
 
-function toggleCenterGuides() {
-	centerGuidesAreVisible = !centerGuidesAreVisible;
-	if (centerGuidesAreVisible) {
+function toggleCenterGuides(event, data) {
+	showCenterGuides = !showCenterGuides;
+
+	if (showCenterGuides === true) {
 		centerGuides.vertical.classList.remove('hidden');
 		centerGuides.horizontal.classList.remove('hidden');
 	} else {

--- a/src/app/ruler/ruler.js
+++ b/src/app/ruler/ruler.js
@@ -158,7 +158,7 @@ ipc.on('toggle-center-guides', toggleCenterGuides);
 function toggleCenterGuides() {
 	showCenterGuides = !showCenterGuides;
 
-	if (showCenterGuides === true) {
+	if (showCenterGuides) {
 		centerGuides.vertical.classList.remove('hidden');
 		centerGuides.horizontal.classList.remove('hidden');
 	} else {

--- a/src/app/ruler/ruler.js
+++ b/src/app/ruler/ruler.js
@@ -147,7 +147,7 @@ window.addEventListener('contextmenu', function (e) {
 
 document.querySelector('.ruler__inner__close').addEventListener('click', () => browserWindow.close());
 document.querySelector('.ruler__inner__theme').addEventListener('click', () => {
-	document.querySelector('.ruler__inner').classList.toggle('dark-theme');
+	toggleTheme();
 });
 
 window.addEventListener('resize', updateMesures);
@@ -165,6 +165,12 @@ function toggleCenterGuides() {
 		centerGuides.vertical.classList.add('hidden');
 		centerGuides.horizontal.classList.add('hidden');
 	}
+}
+
+function toggleTheme() {
+	document.querySelector('.ruler__inner').classList.toggle('dark-theme');
+	document.querySelector('#guide__vertical').classList.toggle('darkCenterGuides');
+	document.querySelector('#guide__horizontal').classList.toggle('darkCenterGuides');
 }
 
 loadSettings();

--- a/src/app/ruler/ruler.js
+++ b/src/app/ruler/ruler.js
@@ -11,13 +11,20 @@ let borders = {
 	top: document.querySelector('.ruler__inner__border--top'),
 	right: document.querySelector('.ruler__inner__border--right'),
 	bottom: document.querySelector('.ruler__inner__border--bottom'),
-	left: document.querySelector('.ruler__inner__border--left'),
+	left: document.querySelector('.ruler__inner__border--left')
 };
 
 let info = {
 	width: document.querySelector('.ruler__inner__info__width'),
 	height: document.querySelector('.ruler__inner__info__height')
 };
+
+let centerGuides = {
+	vertical: document.querySelector('#guide__vertical'),
+	horizontal: document.querySelector('#guide__horizontal')
+};
+
+let centerGuidesAreVisible = false;
 
 let baseFontSize; // Used to calculate em.
 
@@ -37,7 +44,7 @@ let unitStrategies = {
 
 	/**
 	 * Format into to em.
-	 * @param	{px} px - The number of px to convert to em.
+	 * @param {px} px - The number of px to convert to em.
 	 * @return {String} A formatted string displaying em.
 	 */
 	em(em) {
@@ -98,7 +105,7 @@ window.addEventListener('keydown', function(evt) {
 });
 
 window.addEventListener('keyup', function(evt) {
-	//	Keycodes for arrowkeys and shift.
+	// Keycodes for arrowkeys and shift.
 	let up = 38,
 		down = 40,
 		left = 37,
@@ -146,5 +153,17 @@ document.querySelector('.ruler__inner__theme').addEventListener('click', () => {
 window.addEventListener('resize', updateMesures);
 
 ipc.on('settings-changed', loadSettings);
+ipc.on('toggle-center-guides', toggleCenterGuides);
+
+function toggleCenterGuides() {
+	centerGuidesAreVisible = !centerGuidesAreVisible;
+	if (centerGuidesAreVisible) {
+		centerGuides.vertical.classList.remove('hidden');
+		centerGuides.horizontal.classList.remove('hidden');
+	} else {
+		centerGuides.vertical.classList.add('hidden');
+		centerGuides.horizontal.classList.add('hidden');
+	}
+}
 
 loadSettings();

--- a/src/app/ruler/ruler.js
+++ b/src/app/ruler/ruler.js
@@ -26,13 +26,13 @@ let centerGuides = {
 
 let showCenterGuides = false;
 
-let baseFontSize; // Used to calculate em.
+// Used to calculate em.
+let baseFontSize;
 
 let isShiftDown = false;
 
 // This object holds the different strategies for displaying units.
 let unitStrategies = {
-
 	/**
 	 * Format into to pixels.
 	 * @param	{px} px - The number of px to display.
@@ -48,7 +48,7 @@ let unitStrategies = {
 	 * @return {String} A formatted string displaying em.
 	 */
 	em(em) {
-		return `${em/baseFontSize}em`;
+		return `${em / baseFontSize}em`;
 	}
 };
 
@@ -92,7 +92,7 @@ contextMenu.append(new MenuItem({
 	}
 }));
 
-window.addEventListener('keydown', function(evt) {
+window.addEventListener('keydown', function (evt) {
 	let shift = 16;
 
 	switch (evt.keyCode) {
@@ -104,7 +104,7 @@ window.addEventListener('keydown', function(evt) {
 	}
 });
 
-window.addEventListener('keyup', function(evt) {
+window.addEventListener('keyup', function (evt) {
 	// Keycodes for arrowkeys and shift.
 	let up = 38,
 		down = 40,
@@ -155,7 +155,7 @@ window.addEventListener('resize', updateMesures);
 ipc.on('settings-changed', loadSettings);
 ipc.on('toggle-center-guides', toggleCenterGuides);
 
-function toggleCenterGuides(event, data) {
+function toggleCenterGuides() {
 	showCenterGuides = !showCenterGuides;
 
 	if (showCenterGuides === true) {

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -2,17 +2,17 @@
 
 const path = require('path');
 const nconf = require('nconf').file({
-	file: path.join(process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'], '.linear')
+	file: path.join(process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'], '.linear')
 });
 
 module.exports = {
-		saveSettings: function saveSettings(settingKey, settingValue) {
-				nconf.set(settingKey, settingValue);
-				nconf.save();
-		},
+	saveSettings: function saveSettings(settingKey, settingValue) {
+		nconf.set(settingKey, settingValue);
+		nconf.save();
+	},
 
-		readSettings: function readSettings(settingKey) {
-				nconf.load();
-				return nconf.get(settingKey);
-		}
+	readSettings: function readSettings(settingKey) {
+		nconf.load();
+		return nconf.get(settingKey);
+	}
 };


### PR DESCRIPTION
This PR adds center guides to the rulers. You can toggle the visibility of the center guides on or off with the keyboard shortcut <kbd>⌘;</kbd> (which is the same shortcut for toggling guide visibility in Photoshop), or you can use the `Toggle Center Guides` option in the `lr` menu. 

The center guides are not visible by default.

There are also a few small formatting tweaks. To get the center guides to find the exact center of the ruler space, the margins on the top, right, bottom and left needed to be consistent, so a few of the UI elements on the ruler needed to change location slightly. This is what the tweaked ruler looks like (when the center guides are active):

![center-guides](https://cloud.githubusercontent.com/assets/5614571/14067978/0742460e-f46d-11e5-957f-71e724a770d6.png)
