### PR TITLE
higher-contrast universal themes

### DIFF
--- a/src/app/ruler/ruler.css
+++ b/src/app/ruler/ruler.css
@@ -76,17 +76,38 @@ body {
 }
 
 .ruler__inner__info {
+	background-color: rgba(34,34,34,0.3);
 	position: absolute;
-	bottom: 1.2em;
-	left: 5.6em;
-	width: 6.5em;
+	bottom: 1em;
+	left: 4.9em;
+	padding: 3px 5px 3px 3px;
 	font-size: 1.1em;
 	color: white;
+	z-index: 99;
+}
+
+@media (max-width:152px) {
+	.ruler__inner__info {
+		left: 1em;
+	}
+}
+
+.dark-theme .ruler__inner__info {
+	background-color: rgba(255,255,255,0.3);
+	color: black;
+}
+
+.ruler__inner__info__width:before,
+.ruler__inner__info__height:before {
+	width:18px;
+	text-align: center;
+	display: inline-block;
 }
 
 .ruler__inner__info__width:before {
 	content: 'W: ';
 }
+
 .ruler__inner__info__height:before {
 	content: 'H: ';
 }
@@ -148,4 +169,28 @@ body {
 
 .hidden {
 	display: none;
+}
+
+.shdw {
+	-webkit-box-shadow: 1px 1px 1px 0 rgba(119,119,119,0.9);
+	-moz-box-shadow: 1px 1px 1px 0 rgba(119,119,119,0.9);
+	box-shadow: 1px 1px 1px 0 rgba(119,119,119,0.9);
+}
+
+.txtshdw {
+	text-shadow: 1px 1px 1px rgba(119, 119, 119, 0.9);
+}
+
+.dark-theme .shdw {
+	-webkit-box-shadow: 1px 1px 1px 0 rgba(255,255,255,0.9);
+	-moz-box-shadow: 1px 1px 1px 0 rgba(255,255,255,0.9);
+	box-shadow: 1px 1px 1px 0 rgba(255,255,255,0.9);
+}
+
+.dark-theme .txtshdw {
+	text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.9);
+}
+
+.icon {
+	/* placeholder for custom css */
 }

--- a/src/app/ruler/ruler.css
+++ b/src/app/ruler/ruler.css
@@ -78,7 +78,7 @@ body {
 .ruler__inner__info {
 	background-color: rgba(34,34,34,0.3);
 	position: absolute;
-	bottom: 1em;
+	bottom: .6em;
 	left: 4.9em;
 	padding: 3px 5px 3px 3px;
 	font-size: 1.1em;
@@ -93,8 +93,7 @@ body {
 }
 
 .dark-theme .ruler__inner__info {
-	background-color: rgba(255,255,255,0.3);
-	color: black;
+	background-color: rgba(255,255,255,0.7);
 }
 
 .ruler__inner__info__width:before,

--- a/src/app/ruler/ruler.html
+++ b/src/app/ruler/ruler.html
@@ -13,19 +13,19 @@
 		<div class="ruler-mask"></div>
 		<div class="ruler">
 			<div class="ruler__inner">
-				<div class="ruler__inner__title">lr</div>
+				<div class="ruler__inner__title"><span class="txtshdw">lr</span></div>
 				<div class="ruler__inner__info">
-					<div class="ruler__inner__info__width"></div>
-					<div class="ruler__inner__info__height"></div>
+					<div class="ruler__inner__info__width">0px</div>
+					<div class="ruler__inner__info__height">0px</div>
 				</div>
 
-				<div class="ruler__inner__border ruler__inner__border--left"></div>
-				<div class="ruler__inner__border ruler__inner__border--right"></div>
-				<div class="ruler__inner__border ruler__inner__border--top"></div>
-				<div class="ruler__inner__border ruler__inner__border--bottom"></div>
+				<div class="ruler__inner__border ruler__inner__border--left shdw"></div>
+				<div class="ruler__inner__border ruler__inner__border--right shdw"></div>
+				<div class="ruler__inner__border ruler__inner__border--top shdw"></div>
+				<div class="ruler__inner__border ruler__inner__border--bottom shdw"></div>
 
-				<div class="ruler__inner__close close"><i class="fa fa-times-circle"></i></div>
-				<div class="ruler__inner__theme"><i class="fa fa-sun-o"></i></div>
+				<div class="ruler__inner__close close icon"><i class="fa fa-times-circle"></i></div>
+				<div class="ruler__inner__theme icon"><i class="fa fa-sun-o"></i></div>
 			</div>
 		</div>
 		<script src="ruler.js" charset="utf-8"></script>


### PR DESCRIPTION
This PR tweaks the light and dark themes to make them more universal and more readable.

The new themes appear as follows (presented in both light and dark situations to present their universal appeal):
#### Light Theme

![contrast-light](https://cloud.githubusercontent.com/assets/5614571/14177148/d91da2cc-f74c-11e5-9095-550d1e1aec53.png)
#### Dark Theme

![contrast-dark](https://cloud.githubusercontent.com/assets/5614571/14177160/e2930fd6-f74c-11e5-85fe-4f6eb12c5961.png)

In my opinion, the Light theme is so universal (it looks good in both light and dark situations) that you dont even need the dark theme anymore. 

This PR also adds a minor responsive tweak so that the numerical values don't get clipped when drawing a smaller ruler. 

This PR should close #15 
