### PR TITLE
focus rulers after global theme change. Fixes #27

### DIFF
--- a/main.js
+++ b/main.js
@@ -239,6 +239,12 @@ ipc.on('settings-changed', () => {
 // Update the themes of all open rulers on default theme change
 ipc.on('apply-default-theme', (evt, data) => {
 	rulers.forEach(ruler => ruler.send('update-theme', {filename: data.filename}));
+
+	// Focus all rulers temporarily to apply the changes.
+	// See: https://github.com/mikaa123/linear/issues/27
+	setTimeout(() => {
+		rulers.forEach(ruler => ruler.focus());
+	}, 300);
 });
 
 // Duplicate a given ruler.


### PR DESCRIPTION
After the "Apply theme to all open rulers" button has been pressed in the settings, each ruler window gets a moment of focus to apply the theme. There might be a better way to solve this, but at least this solves the problem for now. 
