### PR TITLE
fix(readme): update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Linear is proudly built with [Electron](https://github.com/atom/electron).
 Download the [latest build](https://github.com/mikaa123/linear/releases) or install via homebrew (thanks to [@goronfreeman](https://github.com/goronfreeman)):
 
 ```
-$ brew cask install linear
+$ brew install linear
 ```
 
 ## Caveats


### PR DESCRIPTION
The homebrew cask option is sort of deprecated and you can install GUI packages with the `brew` command directly.

https://stackoverflow.com/questions/30413621/homebrew-cask-option-not-recognized